### PR TITLE
When replacing value in parameters.yml make sed more greedy

### DIFF
--- a/bin/install/toran.sh
+++ b/bin/install/toran.sh
@@ -18,9 +18,9 @@ fi
 
 # Load parameters toran
 cp -f $WORK_DIRECTORY/app/config/parameters.yml.dist $WORK_DIRECTORY/app/config/parameters.yml
-sed -i "s/toran_scheme:/toran_scheme: $TORAN_HTTPS/g" $WORK_DIRECTORY/app/config/parameters.yml
-sed -i "s/toran_host:/toran_host: $TORAN_HOST/g" $WORK_DIRECTORY/app/config/parameters.yml
-sed -i "s/secret:/secret: $TORAN_SECRET/g" $WORK_DIRECTORY/app/config/parameters.yml
+sed -i "s/toran_scheme:.*/toran_scheme: $TORAN_HTTPS/g" $WORK_DIRECTORY/app/config/parameters.yml
+sed -i "s/toran_host.*:/toran_host: $TORAN_HOST/g" $WORK_DIRECTORY/app/config/parameters.yml
+sed -i "s/secret.*:/secret: $TORAN_SECRET/g" $WORK_DIRECTORY/app/config/parameters.yml
 
 # Load toran data
 if [ ! -d $DATA_DIRECTORY/toran ]; then


### PR DESCRIPTION
Now it was not replaced whole line and it ended like this:

`toran_host: localhost     example.org`
