### PR TITLE
Enabled HTTPS env var in vhosts

### DIFF
--- a/assets/vhosts/toran-proxy-https.conf
+++ b/assets/vhosts/toran-proxy-https.conf
@@ -17,7 +17,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param HTTPS off;
+        fastcgi_param HTTPS on;
     }
 
     error_log /data/toran-proxy/logs/nginx/error.log;


### PR DESCRIPTION
The ENV var HTTPS should be set to "on" for https environments
