### PR TITLE
add TORAN_HTTP_PORT and TORAN_HTTPS_PORT to env variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 - Redirection `http` to `https` auto with use https vhost type
 - Generate self-signed certificates automatically
 - Clean create and permissions on logs directory
+- Add option `TORAN_HTTP_PORT` to allow arbitrary http port for nginx / toran proxy
+- Add option `TORAN_HTTPS_PORT` to allow arbitrary https port for nginx / toran proxy
 
 **1.5.1**
 - Upgrade toran proxy to version 1.5.1

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Add `auth.json` to composer configuration home folder
 Below is the complete list of available options that can be used to customize your toran proxy installation.
 
 - **TORAN_HOST**: The hostname of the toran proxy server. Defaults to `localhost`
+- **TORAN_HTTP_PORT**: The port of the toran http server. Defaults to `80`
 - **TORAN_HTTPS**: Set to `true` to enable https support, Defaults to `false`. **If you do not use a reverse proxy, do not forget to add the certificates files**
+- **TORAN_HTTPS_PORT**: The port of the toran https server. Defaults to `443`
 - **TORAN_REVERSE**: Set to `true` if you use docker behind a reverse proxy for i.e. ssl termination. This will make Toran use the HTTPS scheme without the need to add certificates. If you do so, make sure to set your reverse proxy to target port 443. Defaults to `false`
 - **TORAN_CRON_TIMER**: Setup cron job timer. Defaults to `fifteen`
     - `minutes`: All minutes

--- a/assets/vhosts/toran-proxy-http.conf
+++ b/assets/vhosts/toran-proxy-http.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen TORAN_HTTP_PORT default_server;
     server_name _;
 
     root /var/www/web;

--- a/assets/vhosts/toran-proxy-https-reverse.conf
+++ b/assets/vhosts/toran-proxy-https-reverse.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen TORAN_HTTP_PORT default_server;
 
     server_name _;
     access_log off;
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-    listen 443 default_server;
+    listen TORAN_HTTPS_PORT default_server;
     server_name _;
 
     root /var/www/web;

--- a/assets/vhosts/toran-proxy-https.conf
+++ b/assets/vhosts/toran-proxy-https.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen TORAN_HTTP_PORT default_server;
 
     server_name _;
     access_log off;
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-    listen 443 default_server;
+    listen TORAN_HTTPS_PORT default_server;
     server_name _;
 
     ssl on;

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -46,12 +46,18 @@ if [ "${TORAN_HTTPS}" == "true" ]; then
         ln -s $DATA_DIRECTORY/certs /usr/local/share/ca-certificates/toran-proxy
         update-ca-certificates
 
+        sed -i "s|TORAN_HTTP_PORT|$TORAN_HTTP_PORT|g" /etc/nginx/sites-available/toran-proxy-https.conf
+        sed -i "s|TORAN_HTTPS_PORT|$TORAN_HTTPS_PORT|g" /etc/nginx/sites-available/toran-proxy-https.conf
         ln -s /etc/nginx/sites-available/toran-proxy-https.conf /etc/nginx/sites-enabled/toran-proxy-https.conf
 
     else
+        
+        sed -i "s|TORAN_HTTP_PORT|$TORAN_HTTP_PORT|g" /etc/nginx/sites-available/toran-proxy-https-reverse.conf
+        sed -i "s|TORAN_HTTPS_PORT|$TORAN_HTTPS_PORT|g" /etc/nginx/sites-available/toran-proxy-https-reverse.conf
         ln -s /etc/nginx/sites-available/toran-proxy-https-reverse.conf /etc/nginx/sites-enabled/toran-proxy-https-reverse.conf
     fi
 else
+    sed -i "s|TORAN_HTTP_PORT|$TORAN_HTTP_PORT|g" /etc/nginx/sites-available/toran-proxy-http.conf
     ln -s /etc/nginx/sites-available/toran-proxy-http.conf /etc/nginx/sites-enabled/toran-proxy-http.conf
 fi
 

--- a/scripts/install/toran.sh
+++ b/scripts/install/toran.sh
@@ -4,7 +4,9 @@ echo "Configure Toran Proxy..."
 
 # Toran Proxy Configuration
 TORAN_HOST=${TORAN_HOST:-localhost}
+TORAN_HTTP_PORT=${TORAN_HTTP_PORT:-80}
 TORAN_HTTPS=${TORAN_HTTPS:-false}
+TORAN_HTTPS_PORT=${TORAN_HTTPS_PORT:-443}
 TORAN_REVERSE=${TORAN_REVERSE:-false}
 TORAN_CRON_TIMER=${TORAN_CRON_TIMER:-fifteen}
 TORAN_CRON_TIMER_DAILY_TIME=${TORAN_CRON_TIMER_DAILY_TIME:-04:00}
@@ -61,6 +63,8 @@ cp -f $WORK_DIRECTORY/app/config/parameters.yml.dist $WORK_DIRECTORY/app/config/
 sed -i "s|toran_scheme:.*|toran_scheme: $TORAN_SCHEME|g" $WORK_DIRECTORY/app/config/parameters.yml
 sed -i "s|toran_host:.*|toran_host: $TORAN_HOST|g" $WORK_DIRECTORY/app/config/parameters.yml
 sed -i "s|secret:.*|secret: $TORAN_SECRET|g" $WORK_DIRECTORY/app/config/parameters.yml
+sed -i "s|toran_http_port:.*|toran_http_port: $TORAN_HTTP_PORT|g" $WORK_DIRECTORY/app/config/parameters.yml
+sed -i "s|toran_https_port:.*|toran_https_port: $TORAN_HTTPS_PORT|g" $WORK_DIRECTORY/app/config/parameters.yml
 
 # Load toran data
 if [ ! -d $DATA_DIRECTORY/toran ]; then


### PR DESCRIPTION
I have a issue when working on machine with http server running on port 80.

I map toran docker to -p 8099:80 for example. It works for the http UI but the symfony application return http://localhost/repo/etc... to composer not http://localhost:8099/repo...

Inside the container toran_http_port and toran_https_port in parameters.yml are locked on 80/443

I need to map the http/https port inside the docker container to a arbitrary ports (in nginx config and in app/config/parameter.yml) 

So i add two parameters TORAN_HTTP_PORT and TORAN_HTTPS_PORT to the docker container. 
