### PR TITLE
Changes crontab value from '*/1 * * * *' to '0 * * * * *'.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- Fixing wrong declaration of cron "hour" value.
 
 **1.5.2**
 - Upgrade toran proxy to version 1.5.2

--- a/scripts/install/toran.sh
+++ b/scripts/install/toran.sh
@@ -76,7 +76,7 @@ elif [ "${TORAN_CRON_TIMER}" == "fifteen" ]; then
 elif [ "${TORAN_CRON_TIMER}" == "half" ]; then
     CRON_TIMER="*/30 * * * *"
 elif [ "${TORAN_CRON_TIMER}" == "hour" ]; then
-    CRON_TIMER="*/1 * * * *"
+    CRON_TIMER="0 * * * *"
 elif [ "${TORAN_CRON_TIMER}" == "daily" ]; then
     read CRON_TIMER_HOUR CRON_TIMER_MIN <<< ${TORAN_CRON_TIMER_DAILY_TIME//[:]/ }
     CRON_TIMER="$CRON_TIMER_MIN $CRON_TIMER_HOUR * * * *"


### PR DESCRIPTION
The previously declared */1 on the minute cron makes the cronjob run every minute which is not what is expected when setting 'hour'.
