### PR TITLE
open container for customizations during runtime

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- Add custom scripts directory `/data/toran-proxy/scripts` for user customizations to be executed on startup
 
 **1.5.3-1**
 - Enabling HTTP Basic Authentication configuration with `TORAN_AUTH_ENABLE`, `TORAN_AUTH_USER`, and `TORAN_AUTH_PASSWORD` env vars.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ Below is the complete list of available options that can be used to customize yo
 - **TORAN_AUTH_USER**: Configure the HTTP Basic Authentication Username. Defaults to `toran`.
 - **TORAN_AUTH_PASSWORD**: Configure the HTTP Basic Authentication Password. Defaults to `toran`.
 
+## Add customization scripts
+
+For scenarios where the degree of configurability his image offers via the
+above listed options is not sufficient, you are able to add container local
+customization scripts which will get executed during container runtime. Here
+you can add for example sed calls which further tweak the nginx configuration. 
+
+The container `launch.sh` script expects custom scripts to be found under
+`/data/toran-proxy/scripts/*.sh`. These scripts just get sourced in order. 
+
+```bash
+export custdir=/tmp/toran-customs
+mkdir -p $custdir
+echo "echo 'hello world'" > $custdir/hello.sh
+docker run --name toran-proxy -d \
+    -p 443:443 \
+    -v $custdir:/data/toran-proxy/scripts
+    cedvan/toran-proxy:1.5.3-1
+```
+
 ## Toran Proxy License
 
 By default, Toran proxy license is for personal use.

--- a/scripts/install/custom-scripts.sh
+++ b/scripts/install/custom-scripts.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# If any user provided scripts are found source them
+LOCALD="$DATA_DIRECTORY/scripts"
+FILES="$( [ -e $LOCALD ] && find $LOCALD -type f ! -name '\.*' -a -name '*.sh')"
+if [ -n "$FILES" ]; then
+  echo "Running local customization scripts..."
+  for file in $FILES; do
+    echo "-> $file"
+    source $file
+  done
+fi

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -9,6 +9,7 @@ source $SCRIPTS_DIRECTORY/install/toran.sh
 source $SCRIPTS_DIRECTORY/install/ssh.sh
 source $SCRIPTS_DIRECTORY/install/php.sh
 source $SCRIPTS_DIRECTORY/install/nginx.sh
+source $SCRIPTS_DIRECTORY/install/custom-scripts.sh
 
 # Loading logs permissions
 chown -R www-data:www-data \


### PR DESCRIPTION
You are able to mount in your customization scripts under
`/scripts/toran-proxy/local/*.sh` which - if existent - will get sourced
by `launch.sh` during container startup.