### PR TITLE
Make TORAN_SCHEME var independent from TORAN_HTTPS config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- Derive `TORAN_SCHEME` from `TORAN_HTTPS` resp. `TORAN_HTTP` which allows toran to spit out HTTPS links despite being addressed via HTTP (reverse proxy scenario)
 
 **1.5.4**
 - Add custom scripts directory `/data/toran-proxy/scripts` for user customizations to be executed on startup

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -36,9 +36,9 @@ fi
 
 # Checking Toran HTTPS Configuration and load Toran scheme
 if [ "${TORAN_HTTPS}" = "true" ]; then
-    TORAN_SCHEME="https"
+    [ -z "${TORAN_SCHEME}" ] && TORAN_SCHEME="https"
 elif [ "${TORAN_HTTPS}" = "false" ]; then
-    TORAN_SCHEME="http"
+    [ -z "${TORAN_SCHEME}" ] && TORAN_SCHEME="http"
 else
     echo "ERROR: "
     echo "  Variable TORAN_HTTPS isn't valid ! (Values accepted : true/false)"


### PR DESCRIPTION
Unless `TORAN_SCHEME` is set, derive it from `TORAN_HTTPS` variable. But if set, leave this value set and pass it over to the effective toran configuration.

This is useful in scenarios where some kind of reverse proxy or ingress in front of the toran proxy terminates the TLS connections, but we still want Toran to announce its dist url via `https`.