### PR TITLE
upgrade to PHP 7.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 **latest**
 - Add custom scripts directory `/data/toran-proxy/scripts` for user customizations to be executed on startup
 - Update FROM to `ubuntu:14.04`
+- Upgrade to PHP 7.1
 
 **1.5.3-1**
 - Enabling HTTP Basic Authentication configuration with `TORAN_AUTH_ENABLE`, `TORAN_AUTH_USER`, and `TORAN_AUTH_PASSWORD` env vars.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,22 +17,30 @@ RUN apt-get update -qq \
 RUN apt-get update -qq \
     && apt-get install -qqy ssh
 
+# Install PHP 7 repo
+RUN apt-get update -qq \
+    && apt-get install --no-install-recommends -qqy software-properties-common \
+    && LANG=C.UTF-8 add-apt-repository -y ppa:ondrej/php \
+    && apt-get purge -qqy software-properties-common
+
 # Install PHP and Nginx
 RUN apt-get update -qq \
     && apt-get install -qqy \
         git \
         apt-transport-https \
         daemontools \
-        php5-fpm \
-        php5-json \
-        php5-cli \
-        php5-intl \
-        php5-curl \
+        php7.1-fpm \
+        php7.1-json \
+        php7.1-cli \
+        php7.1-intl \
+        php7.1-curl \
+        php7.1-xml \
         nginx \
         apache2-utils
 
 # Configure PHP and Nginx
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+RUN mkdir /run/php \
+    && echo "daemon off;" >> /etc/nginx/nginx.conf
 
 # Version Toran Proxy
 ENV TORAN_PROXY_VERSION 1.5.3
@@ -57,7 +65,9 @@ COPY assets/vhosts /etc/nginx/sites-available
 COPY assets/config /assets/config
 
 # Clean
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get -qqy --purge autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 VOLUME /data/toran-proxy
 

--- a/assets/supervisor/conf.d/php-fpm.conf
+++ b/assets/supervisor/conf.d/php-fpm.conf
@@ -1,6 +1,6 @@
 [program:php-fpm]
 priority = 1
-command = /usr/sbin/php5-fpm -F
+command = /usr/sbin/php-fpm7.1 -F
 autostart = true
 user = root
 redirect_stderr=true

--- a/assets/vhosts/toran-proxy-http.conf
+++ b/assets/vhosts/toran-proxy-http.conf
@@ -13,7 +13,7 @@ server {
     }
 
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/assets/vhosts/toran-proxy-https-reverse.conf
+++ b/assets/vhosts/toran-proxy-https-reverse.conf
@@ -21,7 +21,7 @@ server {
     }
 
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/assets/vhosts/toran-proxy-https.conf
+++ b/assets/vhosts/toran-proxy-https.conf
@@ -25,7 +25,7 @@ server {
     }
 
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/scripts/install/php.sh
+++ b/scripts/install/php.sh
@@ -3,11 +3,11 @@
 echo "Configure PHP..."
 
 # Config PHP Timezone
-sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php5/fpm/php.ini
-sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php5/cli/php.ini
+sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php/7.1/fpm/php.ini
+sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php/7.1/cli/php.ini
 
 # Logs
 mkdir -p $DATA_DIRECTORY/logs/php-fpm
 mkdir -p $DATA_DIRECTORY/logs/php-cli
-sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-fpm/errors.log|g" /etc/php5/fpm/php.ini
-sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-cli/errors.log|g" /etc/php5/cli/php.ini
+sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-fpm/errors.log|g" /etc/php/7.1/fpm/php.ini
+sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-cli/errors.log|g" /etc/php/7.1/cli/php.ini


### PR DESCRIPTION
Fixes #53. There's probably a reasonable way to share the PHP version number (i.e. `7.1`) between the `Dockerfile` and the assets/scripts, but hardcoding it works for now.

Travis is [passing](https://travis-ci.org/ehough/docker-toran-proxy/builds/260083468).