### PR TITLE
Update Toran to Ubuntu 18.04.  PHP 7.2.  Fix breakage.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 - Upgrade PHP 7.1 to PHP 7.2
 - Remove unnecessary PPA
 - Upgrade Ubuntu 14.04 to 18.04
-- Optimize layers by doing all apt and purge as a single run.
+- Optimize layers by doing all apt and purge as a single run. (Down from 499MB to 355MB)
 - Fix the tarball extract and copy
 
 **1.5.4**

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 **latest**
 - Derive `TORAN_SCHEME` from `TORAN_HTTPS` resp. `TORAN_HTTP` which allows toran to spit out HTTPS links despite being addressed via HTTP (reverse proxy scenario)
+- Upgrade PHP 7.1 to PHP 7.2
+- Remove unnecessary PPA
+- Upgrade Ubuntu 14.04 to 18.04
+- Optimize layers by doing all apt and purge as a single run.
+- Fix the tarball extract and copy
 
 **1.5.4**
 - Add custom scripts directory `/data/toran-proxy/scripts` for user customizations to be executed on startup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
+MAINTAINER dev@cedvan.com
 # Install requirements
 RUN apt-get update -y \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,31 @@
-FROM ubuntu:14.04
-MAINTAINER dev@cedvan.com
-
+FROM ubuntu:18.04
+ARG DEBIAN_FRONTEND=noninteractive
 # Install requirements
-RUN apt-get update -qq \
-    && apt-get install -qqy \
+RUN apt-get update -y \
+    && apt-get install -y \
         curl \
         wget \
         ca-certificates \
-        unzip
-
-# Install supervisor
-RUN apt-get update -qq \
-    && apt-get install -qqy supervisor
-
-# Install ssh
-RUN apt-get update -qq \
-    && apt-get install -qqy ssh
-
-# Install PHP 7 repo
-RUN apt-get update -qq \
-    && apt-get install --no-install-recommends -qqy software-properties-common \
-    && LANG=C.UTF-8 add-apt-repository -y ppa:ondrej/php \
-    && apt-get purge -qqy software-properties-common
-
-# Install PHP and Nginx
-RUN apt-get update -qq \
-    && apt-get install -qqy \
+        cron\
+        sudo\
+        git \
+        unzip \
+        supervisor \
+        ssh
         git \
         apt-transport-https \
         daemontools \
-        php7.1-fpm \
-        php7.1-json \
-        php7.1-cli \
-        php7.1-intl \
-        php7.1-curl \
-        php7.1-xml \
+        php7.2-fpm \
+        php7.2-json \
+        php7.2-cli \
+        php7.2-intl \
+        php7.2-curl \
+        php7.2-xml \
         nginx \
-        apache2-utils
+        apache2-utils \
+        && apt-get -y --purge autoremove \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
 
 # Configure PHP and Nginx
 RUN mkdir /run/php \
@@ -46,8 +35,9 @@ RUN mkdir /run/php \
 ENV TORAN_PROXY_VERSION 1.5.4
 
 # Download Toran Proxy
-RUN curl -sL https://toranproxy.com/releases/toran-proxy-v${TORAN_PROXY_VERSION}.tgz | tar xzC /tmp \
-    && mv /tmp/toran /var/www
+RUN mkdir /scratch/
+RUN curl -sL https://toranproxy.com/releases/toran-proxy-v${TORAN_PROXY_VERSION}.tgz | tar xzC /scratch \
+    && mv /scratch/toran/* /var/www
 
 # Load Scripts bash for installing Toran Proxy
 COPY scripts /scripts/toran-proxy/
@@ -63,11 +53,6 @@ COPY assets/supervisor/conf.d /etc/supervisor/conf.d
 COPY assets/supervisor/supervisord.conf /etc/supervisor/supervisord.conf
 COPY assets/vhosts /etc/nginx/sites-available
 COPY assets/config /assets/config
-
-# Clean
-RUN apt-get -qqy --purge autoremove \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 VOLUME /data/toran-proxy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ RUN mkdir /run/php \
 ENV TORAN_PROXY_VERSION 1.5.4
 
 # Download Toran Proxy
-RUN mkdir /scratch/
-RUN curl -sL https://toranproxy.com/releases/toran-proxy-v${TORAN_PROXY_VERSION}.tgz | tar xzC /scratch \
-    && mv /scratch/toran/* /var/www
+RUN mkdir -p /var/www
+RUN curl -sL https://toranproxy.com/releases/toran-proxy-v${TORAN_PROXY_VERSION}.tgz | tar xzC /tmp \
+    && mv /tmp/toran/* /var/www
 
 # Load Scripts bash for installing Toran Proxy
 COPY scripts /scripts/toran-proxy/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y \
         git \
         unzip \
         supervisor \
-        ssh
+        ssh \
         git \
         apt-transport-https \
         daemontools \

--- a/assets/supervisor/conf.d/php-fpm.conf
+++ b/assets/supervisor/conf.d/php-fpm.conf
@@ -1,6 +1,6 @@
 [program:php-fpm]
 priority = 1
-command = /usr/sbin/php-fpm7.1 -F
+command = /usr/sbin/php-fpm7.2 -F
 autostart = true
 user = root
 redirect_stderr=true

--- a/assets/vhosts/toran-proxy-http.conf
+++ b/assets/vhosts/toran-proxy-http.conf
@@ -13,7 +13,7 @@ server {
     }
 
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/assets/vhosts/toran-proxy-https-reverse.conf
+++ b/assets/vhosts/toran-proxy-https-reverse.conf
@@ -21,7 +21,7 @@ server {
     }
 
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/assets/vhosts/toran-proxy-https.conf
+++ b/assets/vhosts/toran-proxy-https.conf
@@ -25,7 +25,7 @@ server {
     }
 
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/scripts/install/php.sh
+++ b/scripts/install/php.sh
@@ -3,11 +3,11 @@
 echo "Configure PHP..."
 
 # Config PHP Timezone
-sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php/7.1/fpm/php.ini
-sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php/7.1/cli/php.ini
+sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php/7.2/fpm/php.ini
+sed -i "s|;date.timezone =.*|date.timezone = ${PHP_TIMEZONE}|g" /etc/php/7.2/cli/php.ini
 
 # Logs
 mkdir -p $DATA_DIRECTORY/logs/php-fpm
 mkdir -p $DATA_DIRECTORY/logs/php-cli
-sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-fpm/errors.log|g" /etc/php/7.1/fpm/php.ini
-sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-cli/errors.log|g" /etc/php/7.1/cli/php.ini
+sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-fpm/errors.log|g" /etc/php/7.2/fpm/php.ini
+sed -i "s|;error_log = php_errors.log|error_log = ${DATA_DIRECTORY}/logs/php-cli/errors.log|g" /etc/php/7.2/cli/php.ini


### PR DESCRIPTION
I know this is a deprecated project, but we'll be using this fork.  Feel free to merge if you like, as it is working.

PHP 7.1 has a serious security flaw that won't be fixed since it's EOL.
The copy after extract does not work without my fix.
Ubuntu 18.04 has 7.2 naively so don't need custom PPA. (And this also means it builds on arm64)

I could also try 20.04, but did not want to risk 7.1 -> 7.4 without also fixing php code.