### PR TITLE
Http2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 **latest**
+- Enable HTTP/2 in Nginx.
 
 **1.5.4-2**
 - Upgrade Ubuntu 18.04 to 20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update -y \
 
 # Configure PHP and Nginx
 RUN mkdir /run/php \
-    && echo "daemon off;" >> /etc/nginx/nginx.conf
+    && echo "daemon off;" >> /etc/nginx/nginx.conf \
+    && echo "ssl_session_cache shared:SSL:5m; ssl_session_timeout 1h;" >> /etc/nginx/conf.d/ssl_session.conf
 
 # Version Toran Proxy
 ENV TORAN_PROXY_VERSION 1.5.4

--- a/assets/vhosts/toran-proxy-https.conf
+++ b/assets/vhosts/toran-proxy-https.conf
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-    listen TORAN_HTTPS_PORT default_server;
+    listen TORAN_HTTPS_PORT ssl http2 default_server;
     server_name _;
 
     # HTTP Basic Authentication
@@ -17,6 +17,8 @@ server {
     ssl on;
     ssl_certificate /data/toran-proxy/certs/toran-proxy.crt;
     ssl_certificate_key /data/toran-proxy/certs/toran-proxy.key;
+    ssl_dhparam /data/toran-proxy/certs/toran-proxy.pem;
+    ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
 
     root /var/www/web;
 

--- a/scripts/install/nginx.sh
+++ b/scripts/install/nginx.sh
@@ -65,6 +65,10 @@ if [ "${TORAN_HTTPS}" == "true" ]; then
 
         fi
 
+        if [ ! -e "${DATA_DIRECTORY}/certs/toran-proxy.pem" ]; then
+            openssl dhparam -out "${DATA_DIRECTORY}/certs/toran-proxy.pem" 2048
+        fi
+
         # Add certificates trusted
         ln -s $DATA_DIRECTORY/certs /usr/local/share/ca-certificates/toran-proxy
         update-ca-certificates


### PR DESCRIPTION
Enable HTTP/2 for NGINX.
Does not break backwards compat.

Should see a huge performance improvement for any client supporting http/2